### PR TITLE
Update the splunk otel agent default settings to match the Helm Chart

### DIFF
--- a/apis/otel/v1alpha1/defaults.go
+++ b/apis/otel/v1alpha1/defaults.go
@@ -37,15 +37,20 @@ func newEnvVarWithFieldRef(name, path string) v1.EnvVar {
 	}
 }
 
-const defaultAgentConfig = `
+const (
+	defaultAgentCPU    = "200m"
+	defaultAgentMemory = "500Mi"
+	defaultAgentConfig = `
 extensions:
   health_check:
     endpoint: '0.0.0.0:13133'
-  zpages:
-    endpoint: '0.0.0.0:55679'
   k8s_observer:
     auth_type: serviceAccount
     node: '${MY_NODE_NAME}'
+  memory_ballast:
+    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+  zpages:
+    endpoint: '0.0.0.0:55679'
 receivers:
   jaeger:
     protocols:
@@ -126,7 +131,6 @@ processors:
       node: '${MY_NODE_NAME}'
   batch: null
   memory_limiter:
-    ballast_size_mib: '${SPLUNK_BALLAST_SIZE_MIB}'
     check_interval: 2s
     limit_mib: '${SPLUNK_MEMORY_LIMIT_MIB}'
   resource:
@@ -161,6 +165,7 @@ service:
   extensions:
     - health_check
     - k8s_observer
+    - memory_ballast
     - zpages
   pipelines:
     traces:
@@ -201,10 +206,14 @@ service:
         - signalfx
 `
 
-const defaultClusterReceiverConfig = `
+	defaultClusterReceiverCPU    = "200m"
+	defaultClusterReceiverMemory = "500Mi"
+	defaultClusterReceiverConfig = `
 extensions:
   health_check:
     endpoint: '0.0.0.0:13133'
+  memory_ballast:
+    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 receivers:
   k8s_cluster:
     auth_type: serviceAccount
@@ -230,7 +239,6 @@ exporters:
 processors:
   batch: null
   memory_limiter:
-    ballast_size_mib: '${SPLUNK_BALLAST_SIZE_MIB}'
     check_interval: 2s
     limit_mib: '${SPLUNK_MEMORY_LIMIT_MIB}'
   resource:
@@ -270,6 +278,7 @@ processors:
 service:
   extensions:
     - health_check
+    - memory_ballast
   pipelines:
     metrics:
       receivers:
@@ -292,10 +301,12 @@ service:
         - signalfx
 `
 
-const defaultClusterReceiverConfigOpenshift = `
+	defaultClusterReceiverConfigOpenshift = `
 extensions:
   health_check:
     endpoint: '0.0.0.0:13133'
+  memory_ballast:
+    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 receivers:
   k8s_cluster:
     distribution: openshift
@@ -322,7 +333,6 @@ exporters:
 processors:
   batch: null
   memory_limiter:
-    ballast_size_mib: '${SPLUNK_BALLAST_SIZE_MIB}'
     check_interval: 2s
     limit_mib: '${SPLUNK_MEMORY_LIMIT_MIB}'
   resource:
@@ -362,6 +372,7 @@ processors:
 service:
   extensions:
     - health_check
+    - memory_ballast
   pipelines:
     metrics:
       receivers:
@@ -381,5 +392,11 @@ service:
         - resource/self
         - resourcedetection
       exporters:
-        - signalfx
+        - signalfxx
 `
+
+	defaultGatewayCPU    = "4"
+	defaultGatewayMemory = "8Gi"
+
+	defaultJavaAgentImage = "quay.io/signalfx/splunk-otel-instrumentation-java:v1.7.1"
+)

--- a/apis/otel/v1alpha1/splunkotelagent_webhook_test.go
+++ b/apis/otel/v1alpha1/splunkotelagent_webhook_test.go
@@ -1,0 +1,97 @@
+// Copyright Splunk Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"testing"
+)
+
+func TestDefaultSpecNoNils(t *testing.T) {
+	var a = Agent{}
+	a.Default()
+	assert.NotNil(t, a.Spec.Realm)
+	assert.NotNil(t, a.Spec.ClusterName)
+	assert.NotNil(t, a.Spec.Agent)
+	assert.NotNil(t, a.Spec.ClusterReceiver)
+	assert.NotNil(t, a.Spec.Gateway)
+	assert.NotNil(t, a.Spec.Instrumentation)
+}
+
+func TestDefaultResourceLimits(t *testing.T) {
+	type testCase struct {
+		in      string
+		outSpec resource.Quantity
+		outEnv  []v1.EnvVar
+	}
+	var a = Agent{}
+	a.Default()
+	testCases := []testCase{
+		{in: defaultAgentCPU, outSpec: a.Spec.Agent.Resources.Limits[v1.ResourceCPU]},
+		{in: defaultAgentMemory, outSpec: a.Spec.Agent.Resources.Limits[v1.ResourceMemory], outEnv: a.Spec.Agent.Env},
+		{in: defaultClusterReceiverCPU, outSpec: a.Spec.ClusterReceiver.Resources.Limits[v1.ResourceCPU]},
+		{in: defaultClusterReceiverMemory, outSpec: a.Spec.ClusterReceiver.Resources.Limits[v1.ResourceMemory],
+			outEnv: a.Spec.ClusterReceiver.Env},
+		{in: defaultGatewayCPU, outSpec: a.Spec.Gateway.Resources.Limits[v1.ResourceCPU]},
+		{in: defaultGatewayMemory, outSpec: a.Spec.Gateway.Resources.Limits[v1.ResourceMemory],
+			outEnv: a.Spec.Gateway.Env},
+	}
+	for _, c := range testCases {
+		assert.Equal(t, resource.MustParse(c.in), c.outSpec)
+		if c.outEnv != nil {
+			found := false
+			for _, i := range c.outEnv {
+				if i.Name == "SPLUNK_MEMORY_TOTAL_MIB" {
+					found = true
+					assert.Equal(t, i.Value, getMemSizeInMiB(resource.MustParse(c.in)))
+				}
+			}
+			assert.True(t, found, "We should have found SPLUNK_MEMORY_TOTAL_MIB in the env variables")
+		}
+	}
+}
+
+func TestGetMemSizeInMiB(t *testing.T) {
+	type testCase struct {
+		in  string
+		out string
+	}
+	testCases := []testCase{
+		{in: "1048575", out: "0"},
+		{in: "1048576", out: "1"},
+		{in: "1023Ki", out: "0"},
+		{in: "1024Ki", out: "1"},
+		{in: "1Mi", out: "1"},
+		{in: "1Gi", out: "1024"},
+		{in: "1Ti", out: "1048576"},
+		{in: "1Pi", out: "1073741824"},
+		{in: "1Ei", out: "1099511627776"},
+		{in: "1048k", out: "0"},
+		{in: "1049k", out: "1"},
+		{in: "1M", out: "0"},
+		{in: "2M", out: "1"},
+		{in: "1G", out: "953"},
+		{in: "1T", out: "953674"},
+		{in: "1P", out: "953674316"},
+		{in: "1E", out: "953674316406"},
+	}
+	for _, c := range testCases {
+		assert.Equal(t, getMemSizeInMiB(resource.MustParse(c.in)), c.out)
+	}
+}


### PR DESCRIPTION
Description:
We want the collector resource configurations between the operator and helm chart to match. I started to moving default values to defaults.go. 
We have a lot of same the parameter/config names defined in multiple places as strings. In a future ticket, I plan on consolidating the parameter/config names into reusable const variables. So I did not do that in this ticket.

Testing:
Added some unit tests. Deployed changes to k8s and verified them manually as well.